### PR TITLE
Add simple React front-end

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -1,5 +1,6 @@
 import { Hono } from "hono";
 import { basicAuth } from "hono/basic-auth";
+import { serveStatic } from "hono/bun";
 import { z } from "zod";
 import { zValidator } from "@hono/zod-validator";
 import env from "./utils/env-vars";
@@ -57,6 +58,9 @@ app.post(
 app.get("/healthz", async (c) => {
   return c.text("OK", 200);
 });
+
+// Serve the front-end from the public directory
+app.get("/*", serveStatic({ root: "./public" }));
 
 export default {
   port: env.APP_PORT,

--- a/public/index.html
+++ b/public/index.html
@@ -1,0 +1,106 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>YNAB Slip Uploader</title>
+  <style>
+    body { font-family: Arial, sans-serif; margin: 40px; }
+    form div { margin-bottom: 10px; }
+    label { display:block; margin-bottom:4px; }
+    input, select, button { padding: 6px; }
+  </style>
+</head>
+<body>
+  <div id="root"></div>
+
+  <!-- React and ReactDOM -->
+  <script src="https://unpkg.com/react@18/umd/react.production.min.js"></script>
+  <script src="https://unpkg.com/react-dom@18/umd/react-dom.production.min.js"></script>
+  <!-- react-hook-form -->
+  <script src="https://unpkg.com/react-hook-form/dist/index.umd.js"></script>
+  <script>
+    const { useState, useEffect } = React;
+    const { useForm } = ReactHookForm;
+
+    function App() {
+      const { register, handleSubmit, reset } = useForm();
+      const [accounts, setAccounts] = useState(() => {
+        const stored = localStorage.getItem('accounts');
+        return stored ? JSON.parse(stored) : [];
+      });
+      const [newAccount, setNewAccount] = useState('');
+      const addAccount = () => {
+        if (newAccount && !accounts.includes(newAccount)) {
+          const updated = [...accounts, newAccount];
+          setAccounts(updated);
+          localStorage.setItem('accounts', JSON.stringify(updated));
+          setNewAccount('');
+        }
+      };
+
+      const onSubmit = async (data) => {
+        if (!data.file?.[0]) {
+          alert('Please select a file');
+          return;
+        }
+        const formData = new FormData();
+        formData.append('account', data.account);
+        formData.append('file', data.file[0]);
+        const auth = btoa(`${data.apiKey}:${data.apiSecret}`);
+        try {
+          const res = await fetch('/upload', {
+            method: 'POST',
+            headers: { 'Authorization': `Basic ${auth}` },
+            body: formData
+          });
+          const result = await res.json();
+          if (!res.ok) {
+            alert(result.error || 'Upload failed');
+          } else {
+            alert('Upload successful');
+            reset();
+          }
+        } catch (err) {
+          alert('Network error');
+        }
+      };
+
+      return React.createElement('div', null,
+        React.createElement('h2', null, 'YNAB Slip Uploader'),
+        React.createElement('form', { onSubmit: handleSubmit(onSubmit) },
+          React.createElement('div', null,
+            React.createElement('label', null, 'API Key'),
+            React.createElement('input', { type: 'text', ...register('apiKey', { required: true }) })
+          ),
+          React.createElement('div', null,
+            React.createElement('label', null, 'API Secret'),
+            React.createElement('input', { type: 'password', ...register('apiSecret', { required: true }) })
+          ),
+          React.createElement('div', null,
+            React.createElement('label', null, 'Bank Account'),
+            React.createElement('select', { ...register('account', { required: true }) },
+              accounts.map(acc => React.createElement('option', { key: acc, value: acc }, acc))
+            )
+          ),
+          React.createElement('div', null,
+            React.createElement('label', null, 'Add Bank Account'),
+            React.createElement('input', {
+              value: newAccount,
+              onChange: e => setNewAccount(e.target.value)
+            }),
+            React.createElement('button', { type: 'button', onClick: addAccount }, 'Add')
+          ),
+          React.createElement('div', null,
+            React.createElement('label', null, 'Slip File'),
+            React.createElement('input', { type: 'file', accept: '.jpg,.jpeg,.png,.webp,.pdf', ...register('file', { required: true }) })
+          ),
+          React.createElement('button', { type: 'submit' }, 'Upload')
+        )
+      );
+    }
+
+    ReactDOM.createRoot(document.getElementById('root')).render(React.createElement(App));
+  </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- serve static files from `public` directory
- add a React single page app that uses `react-hook-form`
  - allows entering API credentials, selecting/adding bank accounts (stored in localStorage)
  - uploads a file to the existing `/upload` endpoint using basic auth

## Testing
- `bun run index.ts` *(fails: ZodError: required env vars)*

------
https://chatgpt.com/codex/tasks/task_e_6868abe76f5483249bd4f95404367432