### PR TITLE
Add simple web front end

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,13 @@ Finally, you can provide a comma-separated list of category groups if you want t
 
 If everything is running, you should get an `OK` response when accessing `/healthz` endpoint.
 
+### Web Form
+
+The container also serves a small React based form at the root path. Open
+`http://localhost:3000/` in your browser and use the form to upload a slip. The
+form stores any bank accounts you enter in your browser's local storage so they
+can be reused the next time you visit.
+
 ### Uploading Slip
 
 Send the following cURL request to upload a slip:

--- a/frontend/app.js
+++ b/frontend/app.js
@@ -1,0 +1,88 @@
+const { useForm } = ReactHookForm;
+
+function App() {
+  const { register, handleSubmit, reset } = useForm();
+  const [accounts, setAccounts] = React.useState(() => {
+    const saved = localStorage.getItem('accounts');
+    return saved ? JSON.parse(saved) : [];
+  });
+  const [newAccount, setNewAccount] = React.useState('');
+
+  const addAccount = () => {
+    const trimmed = newAccount.trim();
+    if (trimmed && !accounts.includes(trimmed)) {
+      const updated = [...accounts, trimmed];
+      setAccounts(updated);
+      localStorage.setItem('accounts', JSON.stringify(updated));
+      setNewAccount('');
+    }
+  };
+
+  const onSubmit = async (data) => {
+    const formData = new FormData();
+    formData.append('account', data.account);
+    formData.append('file', data.file[0]);
+
+    if (!accounts.includes(data.account)) {
+      const updated = [...accounts, data.account];
+      setAccounts(updated);
+      localStorage.setItem('accounts', JSON.stringify(updated));
+    }
+
+    try {
+      const res = await fetch('/upload', {
+        method: 'POST',
+        headers: {
+          'Authorization': 'Basic ' + btoa(data.apiKey + ':' + data.apiSecret)
+        },
+        body: formData
+      });
+
+      if (!res.ok) {
+        const text = await res.text();
+        alert('Upload failed: ' + text);
+      } else {
+        alert('Upload successful');
+        reset();
+      }
+    } catch (err) {
+      alert('Upload failed: ' + err.message);
+    }
+  };
+
+  return (
+    React.createElement('div', null,
+      React.createElement('h1', null, 'YNAB Slip Uploader'),
+      React.createElement('form', { onSubmit: handleSubmit(onSubmit) },
+        React.createElement('div', null,
+          React.createElement('label', null, 'API Key:'),
+          React.createElement('input', { type: 'text', ...register('apiKey', { required: true }) })
+        ),
+        React.createElement('div', null,
+          React.createElement('label', null, 'API Secret:'),
+          React.createElement('input', { type: 'password', ...register('apiSecret', { required: true }) })
+        ),
+        React.createElement('div', null,
+          React.createElement('label', null, 'Bank Account:'),
+          React.createElement('select', { ...register('account', { required: true }) },
+            React.createElement('option', { value: '', disabled: true }, 'Select account'),
+            accounts.map(acc => React.createElement('option', { key: acc, value: acc }, acc))
+          ),
+          React.createElement('input', {
+            value: newAccount,
+            onChange: e => setNewAccount(e.target.value),
+            placeholder: 'Add account'
+          }),
+          React.createElement('button', { type: 'button', onClick: addAccount }, 'Add')
+        ),
+        React.createElement('div', null,
+          React.createElement('label', null, 'Receipt:'),
+          React.createElement('input', { type: 'file', ...register('file', { required: true }) })
+        ),
+        React.createElement('button', { type: 'submit' }, 'Submit')
+      )
+    )
+  );
+}
+
+ReactDOM.createRoot(document.getElementById('root')).render(React.createElement(App));

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>YNAB Slip Uploader</title>
+</head>
+<body>
+  <div id="root"></div>
+  <script crossorigin src="https://unpkg.com/react@18/umd/react.production.min.js"></script>
+  <script crossorigin src="https://unpkg.com/react-dom@18/umd/react-dom.production.min.js"></script>
+  <script crossorigin src="https://unpkg.com/react-hook-form@7/dist/index.umd.js"></script>
+  <script src="./app.js"></script>
+</body>
+</html>

--- a/index.ts
+++ b/index.ts
@@ -1,5 +1,6 @@
 import { Hono } from "hono";
 import { basicAuth } from "hono/basic-auth";
+import { serveStatic } from "hono/bun";
 import { z } from "zod";
 import { zValidator } from "@hono/zod-validator";
 import env from "./utils/env-vars";
@@ -57,6 +58,14 @@ app.post(
 app.get("/healthz", async (c) => {
   return c.text("OK", 200);
 });
+
+app.use(
+  "/*",
+  serveStatic({
+    root: "./frontend",
+    rewriteRequestPath: (path) => (path === "/" ? "/index.html" : path),
+  })
+);
 
 export default {
   port: env.APP_PORT,


### PR DESCRIPTION
## Summary
- serve `frontend` folder with Hono
- document new front-end access in README
- add a basic React-based upload form using React Hook Form

## Testing
- `bun run index.ts` *(fails: missing API credentials)*

------
https://chatgpt.com/codex/tasks/task_e_6868abe76f5483249bd4f95404367432