### PR TITLE
Add Material-UI form

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -13,7 +13,11 @@
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
     "shared": "workspace:*",
-    "server": "workspace:*"
+    "server": "workspace:*",
+    "@mui/material": "^5.15.14",
+    "@mui/icons-material": "^5.14.17",
+    "@emotion/react": "^11.11.4",
+    "@emotion/styled": "^11.11.0"
   },
   "devDependencies": {
     "@eslint/js": "^9.28.0",


### PR DESCRIPTION
## Summary
- integrate Material-UI into the client app
- add a receipt processing form with a creatable autocomplete field
- add file picker, process button and a vertical stepper for progress feedback

## Testing
- `bun run build`


------
https://chatgpt.com/codex/tasks/task_e_686a2d0adbd08324ac78c6c31f152634