### PR TITLE
Add account autocomplete and single category input

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -4,7 +4,6 @@ import {
   Autocomplete,
   Box,
   Button,
-  Chip,
   Container,
   Step,
   StepContent,
@@ -31,9 +30,24 @@ function App() {
     const saved = localStorage.getItem('categories')
     return saved ? JSON.parse(saved) : []
   })
+  const [accounts, setAccounts] = useState<string[]>([])
+  const [account, setAccount] = useState<string | null>(null)
   const [file, setFile] = useState<File | null>(null)
   const [activeStep, setActiveStep] = useState<number>(-1)
   const [logs, setLogs] = useState<string[]>(Array(steps.length).fill(''))
+
+  useEffect(() => {
+    const fetchInfo = async () => {
+      try {
+        const res = await fetch(`${SERVER_URL}/ynab-info`)
+        const info = await res.json()
+        setAccounts(info.accounts || [])
+      } catch (err) {
+        console.error('Error fetching YNAB info', err)
+      }
+    }
+    fetchInfo()
+  }, [])
 
   useEffect(() => {
     localStorage.setItem('categories', JSON.stringify(categories))
@@ -56,6 +70,11 @@ function App() {
   const processReceipt = async () => {
     if (!file) {
       alert('Please select a receipt image')
+      return
+    }
+
+    if (!account) {
+      alert('Please select an account')
       return
     }
 
@@ -99,7 +118,7 @@ function App() {
       await fetch(`${SERVER_URL}/create-transaction`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ account: 'test-account', receipt }),
+        body: JSON.stringify({ account, receipt }),
       })
       updateLog(3, 'Transaction created')
     } catch (err: any) {
@@ -125,18 +144,23 @@ function App() {
     <ThemeProvider theme={theme}>
       <Container maxWidth="sm" sx={{ textAlign: 'center', mt: 4 }}>
         <Autocomplete
-          multiple
+          options={accounts}
+          value={account}
+          onChange={(_, value) => setAccount(value)}
+          renderInput={(params) => (
+            <TextField {...params} label="Account" placeholder="Select account" />
+          )}
+          sx={{ mb: 2 }}
+        />
+        <Autocomplete
           freeSolo
           options={categories}
-          value={categories}
-          onChange={(_, value) => setCategories(value)}
-          renderTags={(value: readonly string[], getTagProps) =>
-            value.map((option, index) => (
-              <Chip label={option} {...getTagProps({ index })} />
-            ))
+          value={categories[0] || null}
+          onChange={(_, value) =>
+            setCategories(value ? [value] : [])
           }
           renderInput={(params) => (
-            <TextField {...params} label="Categories" placeholder="Add category" />
+            <TextField {...params} label="Category" placeholder="Add category" />
           )}
         />
 

--- a/server/src/services/budget.ts
+++ b/server/src/services/budget.ts
@@ -45,11 +45,26 @@ export const getAllPayees = async () => {
   return payees;
 };
 
+export const getAllAccounts = async () => {
+  const budget = await api.budgets.getBudgetById(budgetId);
+
+  const accounts = budget.data.budget.accounts
+    ?.filter((a) => !a.closed && !a.deleted)
+    .map((a) => a.name);
+
+  if (!accounts) {
+    throw new Error("No accounts found");
+  }
+
+  return accounts;
+};
+
 export const getYnabInfo = async () => {
   const categories = await getAllEnvelopes();
   const payees = await getAllPayees();
+  const accounts = await getAllAccounts();
 
-  return { categories, payees };
+  return { categories, payees, accounts };
 };
 
 export const createTransaction = async (


### PR DESCRIPTION
## Summary
- fetch available YNAB accounts on mount
- add account autocomplete input
- limit category autocomplete to a single value
- expose accounts via `getYnabInfo`